### PR TITLE
PLATOPS-1226 - Update dependency for simple-reactivemongo

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     filters,
     "com.typesafe.play" %% "play" % PlayVersion.current % "provided",
     // TODO: Change this to reflect released version
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "6.0.0",
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "6.1.0",
     "uk.gov.hmrc" %% "time" % "3.0.0"
   )
 

--- a/src/main/scala/uk/gov/hmrc/lock/ExclusiveTimePeriodLock.scala
+++ b/src/main/scala/uk/gov/hmrc/lock/ExclusiveTimePeriodLock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/lock/LockKeeper.scala
+++ b/src/main/scala/uk/gov/hmrc/lock/LockKeeper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/lock/LockRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/lock/LockRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/lock/ExclusiveTimePeriodLockSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/lock/ExclusiveTimePeriodLockSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/lock/LockRepositoryConcurrencySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/lock/LockRepositoryConcurrencySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/lock/LockRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/lock/LockRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated simple-reactivemongo dependency to the latest version (removes excessive warnings from the logs).